### PR TITLE
Add support for user defined chromium_config_dir

### DIFF
--- a/src/gn/build_settings.cc
+++ b/src/gn/build_settings.cc
@@ -140,3 +140,8 @@ const BuildSettings::PrintCallback BuildSettings::swap_print_callback(
   print_callback_ = callback;
   return temp;
 }
+
+void BuildSettings::set_chromium_config_dir(const base::FilePath& dir){
+  chromium_config_path_ = dir; 
+  chromium_config_path_utf8_ = FilePathToUTF8(dir);
+}

--- a/src/gn/build_settings.h
+++ b/src/gn/build_settings.h
@@ -90,6 +90,9 @@ class BuildSettings {
   bool use_chromium_config() const { return use_chromium_config_; }
   void set_use_chromium_config(bool u) { use_chromium_config_ = u; }
 
+  // Path to set the Chromium buildconfig directory.
+  void set_chromium_config_dir(const base::FilePath& dir);
+
   const SourceFile& build_config_file() const { return build_config_file_; }
   void set_build_config_file(const SourceFile& f) { build_config_file_ = f; }
 

--- a/src/gn/setup.cc
+++ b/src/gn/setup.cc
@@ -1041,6 +1041,18 @@ bool Setup::FillOtherConfig(const base::CommandLine& cmdline, Err* err) {
   build_settings_.set_use_chromium_config(
       preset_value && preset_value->boolean_value());
 
+  // preset Chromium build config directory of user defined
+  const Value* chromium_config_dir_value =
+      dotfile_scope_.GetValue("chromium_config_dir", true);
+  if (chromium_config_dir_value && !chromium_config_dir_value->VerifyTypeIs(Value::STRING, err)) {
+    err->PrintToStdout();
+    return false;
+  }
+  if(chromium_config_dir_value){
+    build_settings_.set_chromium_config_dir(
+        ResolvePath(chromium_config_dir_value->string_value(),false,build_settings_.root_path()));
+  }
+
   // Build config file.
   if (build_settings_.use_chromium_config()) {
     build_settings_.set_build_config_file(SourceFile(


### PR DESCRIPTION
Consider this project layout:


```
src
    \.gn
    \BUILD.gn
    \gn.exe
    \third_party
        \build-gn (https://github.com/yue/build-gn)
```

We want to use use_chromium_config = true in the .gn file, and set chromium_config_dir = "//third_party/build-gn".

```
use_chromium_config = true
chromium_config_dir = "//third_party/build-gn"
```
This will allow us to directly use `gn gen out\xxx` in the src directory to generate build files.